### PR TITLE
Add missing dependency pinax-boxes

### DIFF
--- a/requirements-ilpycon.txt
+++ b/requirements-ilpycon.txt
@@ -9,3 +9,4 @@ markdown
 pytz
 Pillow
 pinax-pages==0.5.0
+pinax-boxes==3.0.1


### PR DESCRIPTION
When I tried to set up the package according to the instructions, I got
```
~/PyConIsrael/pycon-israel$ ./manage.py migrate             
Traceback (most recent call last):
  File "/home/shai/.virtualenvs/eldarion-pycon-israel/lib/python3.6/site-packages/django/apps/config.py", line 118, in create
    cls = getattr(mod, cls_name)
AttributeError: module 'pinax' has no attribute 'boxes'
```
Installing pinax-boxes solved that.