### PR TITLE
Changed the auth backend so that signup works

### DIFF
--- a/ilpycon/settings.py
+++ b/ilpycon/settings.py
@@ -212,7 +212,7 @@ AUTHENTICATION_BACKENDS = [
     "ilpycon.symposion.teams.backends.TeamPermissionsBackend",
 
     # Auth backends
-    "account.auth_backends.EmailAuthenticationBackend",
+    "account.auth_backends.UsernameAuthenticationBackend",
 ]
 
 CONFERENCE_ID = 1


### PR DESCRIPTION
This is related to https://github.com/pinax/django-user-accounts/pull/280 -- as the project stands, even signup fails because the signup view gives the username to the backends, and the `EmailAuthenticationBackend` uses it as email.
