### PR TITLE
Add venue page, initial structure, initial Hebrew support

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,9 @@ Make sure you are using a virtual environment of some sort (e.g. `virtualenv` or
 npm install
 pip install -r requirements.txt
 ./manage.py migrate
-./manage.py loaddata sites conference sponsor_levels sponsor_benefits proposal_base sitetree
+./manage.py loaddata sites conference sponsor_levels sponsor_benefits proposal_base pages
+./manage.py sitetree_resync_apps ilpycon
+
 npm run dev
 ```
 

--- a/fixtures/pages.json
+++ b/fixtures/pages.json
@@ -4,13 +4,27 @@
   "pk": 1,
   "fields": {
     "title": "Venue",
-    "path": "venue/",
+    "path": "en/venue/",
     "body": "<div style=\"text-align: center\">\r\n    <h3>In 2018 we return to the <a href=\"https://wohl-center.com/\">Wohl Center</a> at BIU</h3>\r\n    <iframe src=\"https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d3380.915966717669!2d34.84451231278844!3d32.07152152693281!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x151d4a1343bd3c2f%3A0xbae89ad91832f38a!2z157XqNeb15Yg15XXldeQ15TXnA!5e0!3m2!1sen!2sil!4v1519500574932\" width=\"600\" height=\"450\" frameborder=\"0\" style=\"border:0\" allowfullscreen></iframe>\r\n</div>",
     "body_html": "<div style=\"text-align: center\">\n    <h3>In 2018 we return to the <a href=\"https://wohl-center.com/\">Wohl Center</a> at BIU</h3>\n    <iframe src=\"https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d3380.915966717669!2d34.84451231278844!3d32.07152152693281!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x151d4a1343bd3c2f%3A0xbae89ad91832f38a!2z157XqNeb15Yg15XXldeQ15TXnA!5e0!3m2!1sen!2sil!4v1519500574932\" width=\"600\" height=\"450\" frameborder=\"0\" style=\"border:0\" allowfullscreen></iframe>\n</div>",
     "status": 2,
-    "publish_date": "2018-02-28T00:07:21.930Z",
+    "publish_date": "2018-02-28T00:07:21Z",
     "created": "2018-02-28T00:07:21.930Z",
-    "updated": "2018-02-28T00:07:21.931Z"
+    "updated": "2018-02-28T21:42:01.401Z"
+  }
+},
+{
+  "model": "pinax_pages.page",
+  "pk": 2,
+  "fields": {
+    "title": "\u05de\u05e7\u05d5\u05dd",
+    "path": "he/venue/",
+    "body": "<div style=\"text-align: center\" dir=\"rtl\">\r\n    <h3>\u05d1\u05be2018 \u05d0\u05e0\u05d5 \u05d7\u05d5\u05d6\u05e8\u05d9\u05dd \u05dc<a href=\"https://wohl-center.com/\">\u05de\u05e8\u05db\u05d6 \u05d5\u05d5\u05d0\u05d4\u05dc</a> \u05d1\u05d0\u05d5\u05e0\u05d9\u05d1\u05e8\u05e1\u05d9\u05d8\u05ea \u05d1\u05e8\u05be\u05d0\u05d9\u05dc\u05df</h3>\r\n    <iframe src=\"https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d3380.915966717669!2d34.84451231278844!3d32.07152152693281!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x151d4a1343bd3c2f%3A0xbae89ad91832f38a!2z157XqNeb15Yg15XXldeQ15TXnA!5e0!3m2!1sen!2sil!4v1519500574932\" width=\"600\" height=\"450\" frameborder=\"0\" style=\"border:0\" allowfullscreen></iframe>\r\n</div>",
+    "body_html": "<div style=\"text-align: center\" dir=\"rtl\">\n    <h3>\u05d1\u05be2018 \u05d0\u05e0\u05d5 \u05d7\u05d5\u05d6\u05e8\u05d9\u05dd \u05dc<a href=\"https://wohl-center.com/\">\u05de\u05e8\u05db\u05d6 \u05d5\u05d5\u05d0\u05d4\u05dc</a> \u05d1\u05d0\u05d5\u05e0\u05d9\u05d1\u05e8\u05e1\u05d9\u05d8\u05ea \u05d1\u05e8\u05be\u05d0\u05d9\u05dc\u05df</h3>\n    <iframe src=\"https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d3380.915966717669!2d34.84451231278844!3d32.07152152693281!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x151d4a1343bd3c2f%3A0xbae89ad91832f38a!2z157XqNeb15Yg15XXldeQ15TXnA!5e0!3m2!1sen!2sil!4v1519500574932\" width=\"600\" height=\"450\" frameborder=\"0\" style=\"border:0\" allowfullscreen></iframe>\n</div>",
+    "status": 2,
+    "publish_date": "2018-02-28T21:42:01Z",
+    "created": "2018-02-28T21:43:43.790Z",
+    "updated": "2018-03-01T00:45:25.562Z"
   }
 },
 {
@@ -25,6 +39,76 @@
     "status": 2,
     "publish_date": "2018-02-28T00:07:21.930Z",
     "created": "2018-02-28T00:07:22.106Z"
+  }
+},
+{
+  "model": "pinax_pages.pagehistory",
+  "pk": 2,
+  "fields": {
+    "page": 1,
+    "title": "Venue",
+    "path": "en/venue/",
+    "body": "<div style=\"text-align: center\">\r\n    <h3>In 2018 we return to the <a href=\"https://wohl-center.com/\">Wohl Center</a> at BIU</h3>\r\n    <iframe src=\"https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d3380.915966717669!2d34.84451231278844!3d32.07152152693281!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x151d4a1343bd3c2f%3A0xbae89ad91832f38a!2z157XqNeb15Yg15XXldeQ15TXnA!5e0!3m2!1sen!2sil!4v1519500574932\" width=\"600\" height=\"450\" frameborder=\"0\" style=\"border:0\" allowfullscreen></iframe>\r\n</div>",
+    "body_html": "<div style=\"text-align: center\">\n    <h3>In 2018 we return to the <a href=\"https://wohl-center.com/\">Wohl Center</a> at BIU</h3>\n    <iframe src=\"https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d3380.915966717669!2d34.84451231278844!3d32.07152152693281!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x151d4a1343bd3c2f%3A0xbae89ad91832f38a!2z157XqNeb15Yg15XXldeQ15TXnA!5e0!3m2!1sen!2sil!4v1519500574932\" width=\"600\" height=\"450\" frameborder=\"0\" style=\"border:0\" allowfullscreen></iframe>\n</div>",
+    "status": 2,
+    "publish_date": "2018-02-28T00:07:21Z",
+    "created": "2018-02-28T21:38:41.414Z"
+  }
+},
+{
+  "model": "pinax_pages.pagehistory",
+  "pk": 3,
+  "fields": {
+    "page": 1,
+    "title": "Venue",
+    "path": "en/venue/",
+    "body": "<div style=\"text-align: center\">\r\n    <h3>In 2018 we return to the <a href=\"https://wohl-center.com/\">Wohl Center</a> at BIU</h3>\r\n    <iframe src=\"https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d3380.915966717669!2d34.84451231278844!3d32.07152152693281!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x151d4a1343bd3c2f%3A0xbae89ad91832f38a!2z157XqNeb15Yg15XXldeQ15TXnA!5e0!3m2!1sen!2sil!4v1519500574932\" width=\"600\" height=\"450\" frameborder=\"0\" style=\"border:0\" allowfullscreen></iframe>\r\n</div>",
+    "body_html": "<div style=\"text-align: center\">\n    <h3>In 2018 we return to the <a href=\"https://wohl-center.com/\">Wohl Center</a> at BIU</h3>\n    <iframe src=\"https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d3380.915966717669!2d34.84451231278844!3d32.07152152693281!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x151d4a1343bd3c2f%3A0xbae89ad91832f38a!2z157XqNeb15Yg15XXldeQ15TXnA!5e0!3m2!1sen!2sil!4v1519500574932\" width=\"600\" height=\"450\" frameborder=\"0\" style=\"border:0\" allowfullscreen></iframe>\n</div>",
+    "status": 2,
+    "publish_date": "2018-02-28T00:07:21Z",
+    "created": "2018-02-28T21:42:01.403Z"
+  }
+},
+{
+  "model": "pinax_pages.pagehistory",
+  "pk": 4,
+  "fields": {
+    "page": 2,
+    "title": "\u05de\u05e7\u05d5\u05dd",
+    "path": "he/venue",
+    "body": "<div style=\"text-align: center\">\r\n    <h3>\u05d1\u05be2018 \u05d0\u05e0\u05d5 \u05d7\u05d5\u05d6\u05e8\u05d9\u05dd \u05dc<a href=\"https://wohl-center.com/\">\u05de\u05e8\u05db\u05d6 \u05d5\u05d5\u05d0\u05d4\u05dc</a>\u05d1\u05d0\u05d5\u05e0\u05d9\u05d1\u05e8\u05e1\u05d9\u05d8\u05ea \u05d1\u05e8\u05be\u05d0\u05d9\u05dc\u05df</h3>\r\n    <iframe src=\"https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d3380.915966717669!2d34.84451231278844!3d32.07152152693281!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x151d4a1343bd3c2f%3A0xbae89ad91832f38a!2z157XqNeb15Yg15XXldeQ15TXnA!5e0!3m2!1sen!2sil!4v1519500574932\" width=\"600\" height=\"450\" frameborder=\"0\" style=\"border:0\" allowfullscreen></iframe>\r\n</div>",
+    "body_html": "<div style=\"text-align: center\">\n    <h3>\u05d1\u05be2018 \u05d0\u05e0\u05d5 \u05d7\u05d5\u05d6\u05e8\u05d9\u05dd \u05dc<a href=\"https://wohl-center.com/\">\u05de\u05e8\u05db\u05d6 \u05d5\u05d5\u05d0\u05d4\u05dc</a>\u05d1\u05d0\u05d5\u05e0\u05d9\u05d1\u05e8\u05e1\u05d9\u05d8\u05ea \u05d1\u05e8\u05be\u05d0\u05d9\u05dc\u05df</h3>\n    <iframe src=\"https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d3380.915966717669!2d34.84451231278844!3d32.07152152693281!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x151d4a1343bd3c2f%3A0xbae89ad91832f38a!2z157XqNeb15Yg15XXldeQ15TXnA!5e0!3m2!1sen!2sil!4v1519500574932\" width=\"600\" height=\"450\" frameborder=\"0\" style=\"border:0\" allowfullscreen></iframe>\n</div>",
+    "status": 2,
+    "publish_date": "2018-02-28T21:42:01Z",
+    "created": "2018-02-28T21:43:43.793Z"
+  }
+},
+{
+  "model": "pinax_pages.pagehistory",
+  "pk": 5,
+  "fields": {
+    "page": 2,
+    "title": "\u05de\u05e7\u05d5\u05dd",
+    "path": "he/venue/",
+    "body": "<div style=\"text-align: center\">\r\n    <h3>\u05d1\u05be2018 \u05d0\u05e0\u05d5 \u05d7\u05d5\u05d6\u05e8\u05d9\u05dd \u05dc<a href=\"https://wohl-center.com/\">\u05de\u05e8\u05db\u05d6 \u05d5\u05d5\u05d0\u05d4\u05dc</a>\u05d1\u05d0\u05d5\u05e0\u05d9\u05d1\u05e8\u05e1\u05d9\u05d8\u05ea \u05d1\u05e8\u05be\u05d0\u05d9\u05dc\u05df</h3>\r\n    <iframe src=\"https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d3380.915966717669!2d34.84451231278844!3d32.07152152693281!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x151d4a1343bd3c2f%3A0xbae89ad91832f38a!2z157XqNeb15Yg15XXldeQ15TXnA!5e0!3m2!1sen!2sil!4v1519500574932\" width=\"600\" height=\"450\" frameborder=\"0\" style=\"border:0\" allowfullscreen></iframe>\r\n</div>",
+    "body_html": "<div style=\"text-align: center\">\n    <h3>\u05d1\u05be2018 \u05d0\u05e0\u05d5 \u05d7\u05d5\u05d6\u05e8\u05d9\u05dd \u05dc<a href=\"https://wohl-center.com/\">\u05de\u05e8\u05db\u05d6 \u05d5\u05d5\u05d0\u05d4\u05dc</a>\u05d1\u05d0\u05d5\u05e0\u05d9\u05d1\u05e8\u05e1\u05d9\u05d8\u05ea \u05d1\u05e8\u05be\u05d0\u05d9\u05dc\u05df</h3>\n    <iframe src=\"https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d3380.915966717669!2d34.84451231278844!3d32.07152152693281!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x151d4a1343bd3c2f%3A0xbae89ad91832f38a!2z157XqNeb15Yg15XXldeQ15TXnA!5e0!3m2!1sen!2sil!4v1519500574932\" width=\"600\" height=\"450\" frameborder=\"0\" style=\"border:0\" allowfullscreen></iframe>\n</div>",
+    "status": 2,
+    "publish_date": "2018-02-28T21:42:01Z",
+    "created": "2018-03-01T00:43:47.816Z"
+  }
+},
+{
+  "model": "pinax_pages.pagehistory",
+  "pk": 6,
+  "fields": {
+    "page": 2,
+    "title": "\u05de\u05e7\u05d5\u05dd",
+    "path": "he/venue/",
+    "body": "<div style=\"text-align: center\" dir=\"rtl\">\r\n    <h3>\u05d1\u05be2018 \u05d0\u05e0\u05d5 \u05d7\u05d5\u05d6\u05e8\u05d9\u05dd \u05dc<a href=\"https://wohl-center.com/\">\u05de\u05e8\u05db\u05d6 \u05d5\u05d5\u05d0\u05d4\u05dc</a> \u05d1\u05d0\u05d5\u05e0\u05d9\u05d1\u05e8\u05e1\u05d9\u05d8\u05ea \u05d1\u05e8\u05be\u05d0\u05d9\u05dc\u05df</h3>\r\n    <iframe src=\"https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d3380.915966717669!2d34.84451231278844!3d32.07152152693281!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x151d4a1343bd3c2f%3A0xbae89ad91832f38a!2z157XqNeb15Yg15XXldeQ15TXnA!5e0!3m2!1sen!2sil!4v1519500574932\" width=\"600\" height=\"450\" frameborder=\"0\" style=\"border:0\" allowfullscreen></iframe>\r\n</div>",
+    "body_html": "<div style=\"text-align: center\" dir=\"rtl\">\n    <h3>\u05d1\u05be2018 \u05d0\u05e0\u05d5 \u05d7\u05d5\u05d6\u05e8\u05d9\u05dd \u05dc<a href=\"https://wohl-center.com/\">\u05de\u05e8\u05db\u05d6 \u05d5\u05d5\u05d0\u05d4\u05dc</a> \u05d1\u05d0\u05d5\u05e0\u05d9\u05d1\u05e8\u05e1\u05d9\u05d8\u05ea \u05d1\u05e8\u05be\u05d0\u05d9\u05dc\u05df</h3>\n    <iframe src=\"https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d3380.915966717669!2d34.84451231278844!3d32.07152152693281!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x151d4a1343bd3c2f%3A0xbae89ad91832f38a!2z157XqNeb15Yg15XXldeQ15TXnA!5e0!3m2!1sen!2sil!4v1519500574932\" width=\"600\" height=\"450\" frameborder=\"0\" style=\"border:0\" allowfullscreen></iframe>\n</div>",
+    "status": 2,
+    "publish_date": "2018-02-28T21:42:01Z",
+    "created": "2018-03-01T00:45:25.563Z"
   }
 }
 ]

--- a/fixtures/pages.json
+++ b/fixtures/pages.json
@@ -1,0 +1,30 @@
+[
+{
+  "model": "pinax_pages.page",
+  "pk": 1,
+  "fields": {
+    "title": "Venue",
+    "path": "venue/",
+    "body": "<div style=\"text-align: center\">\r\n    <h3>In 2018 we return to the <a href=\"https://wohl-center.com/\">Wohl Center</a> at BIU</h3>\r\n    <iframe src=\"https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d3380.915966717669!2d34.84451231278844!3d32.07152152693281!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x151d4a1343bd3c2f%3A0xbae89ad91832f38a!2z157XqNeb15Yg15XXldeQ15TXnA!5e0!3m2!1sen!2sil!4v1519500574932\" width=\"600\" height=\"450\" frameborder=\"0\" style=\"border:0\" allowfullscreen></iframe>\r\n</div>",
+    "body_html": "<div style=\"text-align: center\">\n    <h3>In 2018 we return to the <a href=\"https://wohl-center.com/\">Wohl Center</a> at BIU</h3>\n    <iframe src=\"https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d3380.915966717669!2d34.84451231278844!3d32.07152152693281!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x151d4a1343bd3c2f%3A0xbae89ad91832f38a!2z157XqNeb15Yg15XXldeQ15TXnA!5e0!3m2!1sen!2sil!4v1519500574932\" width=\"600\" height=\"450\" frameborder=\"0\" style=\"border:0\" allowfullscreen></iframe>\n</div>",
+    "status": 2,
+    "publish_date": "2018-02-28T00:07:21.930Z",
+    "created": "2018-02-28T00:07:21.930Z",
+    "updated": "2018-02-28T00:07:21.931Z"
+  }
+},
+{
+  "model": "pinax_pages.pagehistory",
+  "pk": 1,
+  "fields": {
+    "page": 1,
+    "title": "Venue",
+    "path": "venue/",
+    "body": "<div style=\"text-align: center\">\r\n    <h3>In 2018 we return to the <a href=\"https://wohl-center.com/\">Wohl Center</a> at BIU</h3>\r\n    <iframe src=\"https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d3380.915966717669!2d34.84451231278844!3d32.07152152693281!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x151d4a1343bd3c2f%3A0xbae89ad91832f38a!2z157XqNeb15Yg15XXldeQ15TXnA!5e0!3m2!1sen!2sil!4v1519500574932\" width=\"600\" height=\"450\" frameborder=\"0\" style=\"border:0\" allowfullscreen></iframe>\r\n</div>",
+    "body_html": "<div style=\"text-align: center\">\n    <h3>In 2018 we return to the <a href=\"https://wohl-center.com/\">Wohl Center</a> at BIU</h3>\n    <iframe src=\"https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d3380.915966717669!2d34.84451231278844!3d32.07152152693281!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x151d4a1343bd3c2f%3A0xbae89ad91832f38a!2z157XqNeb15Yg15XXldeQ15TXnA!5e0!3m2!1sen!2sil!4v1519500574932\" width=\"600\" height=\"450\" frameborder=\"0\" style=\"border:0\" allowfullscreen></iframe>\n</div>",
+    "status": 2,
+    "publish_date": "2018-02-28T00:07:21.930Z",
+    "created": "2018-02-28T00:07:22.106Z"
+  }
+}
+]

--- a/ilpycon/settings.py
+++ b/ilpycon/settings.py
@@ -1,5 +1,6 @@
 import os
 
+from django.utils.translation import gettext_lazy as _
 
 PROJECT_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir))
 PACKAGE_ROOT = os.path.abspath(os.path.dirname(__file__))
@@ -29,7 +30,11 @@ TIME_ZONE = "UTC"
 
 # Language code for this installation. All choices can be found here:
 # http://www.i18nguy.com/unicode/language-identifiers.html
-LANGUAGE_CODE = "en-us"
+LANGUAGE_CODE = "en"
+LANGUAGES = [
+    ('en', _('English')),
+    ('he', _('Hebrew')),
+]
 
 SITE_ID = int(os.environ.get("SITE_ID", 1))
 
@@ -108,6 +113,7 @@ TEMPLATES = [
 
 MIDDLEWARE = [
     "django.contrib.sessions.middleware.SessionMiddleware",
+    "django.middleware.locale.LocaleMiddleware",
     "django.middleware.common.CommonMiddleware",
     "django.middleware.csrf.CsrfViewMiddleware",
     "django.contrib.auth.middleware.AuthenticationMiddleware",
@@ -216,6 +222,10 @@ AUTHENTICATION_BACKENDS = [
     # Auth backends
     "account.auth_backends.UsernameAuthenticationBackend",
 ]
+
+# In a future version of sitetree, this ensures menus are
+# defined in source, not database. Currently does nothing.
+SITETREE_DYNAMIC_ONLY = True
 
 CONFERENCE_ID = 1
 SYMPOSION_PAGE_REGEX = r"(([\w-]{1,})(/[\w-]{1,})*)/"

--- a/ilpycon/sitetrees.py
+++ b/ilpycon/sitetrees.py
@@ -1,0 +1,37 @@
+"""
+Site trees defining the menus for the PyCon-Israel site
+"""
+
+from sitetree.utils import tree, item
+
+sitetrees = (
+  # A tree for English will serve as the default for now
+  tree('main', 'main', items=[
+      item('Home', 'home'),
+      item('About', 'pinax_pages:pages_page "en/about/"'),
+      item('Code of Conduct', 'pinax_pages:pages_page "en/code-of-conduct/"'),
+      item('Venue', 'pinax_pages:pages_page "en/venue/"'),
+      item('Sponsors', '#', children=[
+          item('Apply to be a Sponsor', 'sponsor_apply'),
+          item('{{ SITE_NAME }} Sponsors', 'sponsor_list'),
+      ]),
+  ]),
+
+  tree('main_he', title='ראשי', items=[
+      item('עמוד הבית', 'home'),
+      item('אודות', 'pinax_pages:pages_page "he/about/"'),
+      item('כללי התנהגות', 'pinax_pages:pages_page "he/code-of-conduct/"'),
+      item('מקום', 'pinax_pages:pages_page "he/venue/"'),
+      item('חסויות', '#', children=[
+          item('הצע חסות', 'sponsor_apply'),
+          item('נותני החסות ל־{{ SITE_NAME }}', 'sponsor_list'),
+      ]),
+  ]),
+
+      # item('Title', 'url', children=[
+      #     item('Book named "{{ book.title }}"', 'books-details', in_menu=False, in_sitetree=False),
+      #     item('Add a book', 'books-add'),
+      #     item('Edit "{{ book.title }}"', 'books-edit', in_menu=False, in_sitetree=False)
+      # ])
+  # ... You can define more than one tree for your app.
+)

--- a/ilpycon/templates/_language_bar.html
+++ b/ilpycon/templates/_language_bar.html
@@ -1,0 +1,11 @@
+{% load i18n %}
+
+<form action="{% url 'set_language' %}" method="post" class="navbar-nav">{% csrf_token %}
+    {# <input name="next" type="hidden" value="{{ redirect_to }}" /> #}
+    {% get_current_language as LANGUAGE_CODE %}
+    {% get_available_languages as LANGUAGES %}
+    {% get_language_info_list for LANGUAGES as languages %}
+    {% for language in languages %}
+       <button name="language" value="{{ language.code }}"{% if language.code == LANGUAGE_CODE %} disabled{% endif %}>{{ language.name_local }}</button>
+    {% endfor %}
+</form>

--- a/ilpycon/templates/site_base.html
+++ b/ilpycon/templates/site_base.html
@@ -16,6 +16,7 @@
     {% block extra_head %}{% endblock %}
 {% endblock %}
 
+{% block body_extra_attributes %}{% if LANGUAGE_BIDI %}dir="rtl"{% endif %}{% endblock %}
 
 {% block topbar_base %}
 <header>
@@ -41,6 +42,7 @@
                     </ul>
                 {% endblock %}
                 {% block account_bar %}{% include "_account_bar.html" %}{% endblock %}
+                {% block language_bar %}{% include "_language_bar.html" %}{% endblock %}
             </div>
         {% endblock %}
         </div>

--- a/ilpycon/urls.py
+++ b/ilpycon/urls.py
@@ -5,6 +5,10 @@ from django.views.generic import TemplateView
 
 from django.contrib import admin
 
+from sitetree.sitetreeapp import (
+    register_dynamic_trees, compose_dynamic_tree, register_i18n_trees
+)
+
 from .symposion.views import dashboard
 
 WIKI_SLUG = r"(([\w-]{2,})(/[\w-]{2,})*)"
@@ -12,6 +16,7 @@ WIKI_SLUG = r"(([\w-]{2,})(/[\w-]{2,})*)"
 urlpatterns = [
     path("", TemplateView.as_view(template_name="homepage.html"), name="home"),
     path("admin/", admin.site.urls),
+    path("i18n/", include('django.conf.urls.i18n')),
     path("account/", include("account.urls")),
 
     path("dashboard/", dashboard, name="dashboard"),
@@ -25,4 +30,8 @@ urlpatterns = [
     path("", include("pinax.pages.urls", namespace="pinax_pages"))
 ]
 
+
 urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
+
+register_dynamic_trees(compose_dynamic_tree('ilpycon'), reset_cache=True)
+register_i18n_trees(['main'])


### PR DESCRIPTION
This adds initial Hebrew support and initial list of pages to the website.

Note changes in README.md -- I moved the sitetrees definition from fixture to code, as it is much easier to manage the parallel two trees this way.